### PR TITLE
renamed php-cs-fixer config file and use contructor PhpCsFixer\Config…

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,8 +7,6 @@ $finder = PhpCsFixer\Finder::create()
         __DIR__.'/tests'
     ]);
 
-return PhpCsFixer\Config::create()
-    ->setRules([
-        '@Symfony' => true,
-    ])->setFinder($finder);
-
+$config = new PhpCsFixer\Config();
+return $config->setRules(['@Symfony' => true])
+    ->setFinder($finder);


### PR DESCRIPTION
$ composer check-style

Deprecation example:

```
Detected deprecations in use:
- Configuration file `.php_cs` is deprecated, rename to `.php-cs-fixer.php`.
- PhpCsFixer\Config::create is deprecated since 2.17 and will be removed in 3.0, use the constructor instead.
```