### PR TITLE
Added support for the `swisnl/json-api-client:^2.0` package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
       "test": "XDEBUG_MODE=coverage phpunit",
       "check-style": "php-cs-fixer fix --dry-run -v",
       "fix-style": "php-cs-fixer fix"
-    }
+    },
+    "config": {
+      "allow-plugins": {
+        "php-http/discovery": true
+      }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
       "php": ">=7.4",
-      "swisnl/json-api-client": "1.3.2",
+      "swisnl/json-api-client": "^1.3.2|^2.0",
+      "illuminate/support": "^5.5|^6.0|^7.0|^8.0",
       "guzzlehttp/guzzle": "^7.0",
       "phpseclib/phpseclib": "^3.0.7",
       "ext-openssl": "*",


### PR DESCRIPTION
Package `swisnl/json-api-client` is restricted to version `1.3.2` . It leads to deprecation warnings like `Deprecated: Return type of Swis\JsonApi\Client\Meta::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`   
This deprecation should be fixed in the version 2 of the package.   
For backward compatibility the usage of version `1.3.2` is still allowed