### PR TITLE
Fixed the return values of `\Didww\Item\BaseItem`'s children

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,10 @@
       "test": "XDEBUG_MODE=coverage phpunit",
       "check-style": "php-cs-fixer fix --dry-run -v",
       "fix-style": "php-cs-fixer fix"
-    }
+    },
+    "config": {
+      "allow-plugins": {
+        "php-http/discovery": true
+      }
+  }
 }

--- a/src/Item/CapacityPool.php
+++ b/src/Item/CapacityPool.php
@@ -29,9 +29,9 @@ class CapacityPool extends BaseItem
         return $this->getAttributes()['name'];
     }
 
-    public function getRenewDate(): \Date
+    public function getRenewDate(): \DateTime
     {
-        return new \Date($this->getAttributes()['renew_date']);
+        return new \DateTime($this->getAttributes()['renew_date']);
     }
 
     public function getTotalChannelsCount(): int

--- a/src/Item/Configuration/Base.php
+++ b/src/Item/Configuration/Base.php
@@ -27,6 +27,8 @@ abstract class Base extends \Didww\Item\BaseItem
     public function fill(array $attributes)
     {
         $this->attributes = $attributes;
+
+        return $this;
     }
 
     private static $didPlaceHolder = '{DID}';

--- a/src/Item/Order.php
+++ b/src/Item/Order.php
@@ -47,6 +47,7 @@ class Order extends BaseItem
             $this->fillItems($attributes['items']);
             unset($attributes['items']);
         }
+
         return parent::fill($attributes);
     }
 

--- a/src/Item/Order.php
+++ b/src/Item/Order.php
@@ -47,7 +47,7 @@ class Order extends BaseItem
             $this->fillItems($attributes['items']);
             unset($attributes['items']);
         }
-        parent::fill($attributes);
+        return parent::fill($attributes);
     }
 
     private function fillItems($items)

--- a/src/Item/OrderItem/Base.php
+++ b/src/Item/OrderItem/Base.php
@@ -38,12 +38,17 @@ abstract class Base implements \Swis\JsonApi\Client\Interfaces\DataInterface
         return $creatableAttributes;
     }
 
-    public function fill(array $attributes)
+    /**
+     * @return $this
+     */
+    public function fill(array $attributes): self
     {
         // remove deprecated attributes
         unset($attributes['monthly_price']);
         unset($attributes['setup_price']);
         $this->attributes = $attributes;
+
+        return $this;
     }
 
     public function getNrc(): float

--- a/src/Item/VoiceInTrunk.php
+++ b/src/Item/VoiceInTrunk.php
@@ -156,6 +156,7 @@ class VoiceInTrunk extends BaseItem
             $this->fillConfiguration($attributes['configuration']);
             unset($attributes['configuration']);
         }
+
         return parent::fill($attributes);
     }
 

--- a/src/Item/VoiceInTrunk.php
+++ b/src/Item/VoiceInTrunk.php
@@ -156,7 +156,7 @@ class VoiceInTrunk extends BaseItem
             $this->fillConfiguration($attributes['configuration']);
             unset($attributes['configuration']);
         }
-        parent::fill($attributes);
+        return parent::fill($attributes);
     }
 
     private function fillConfiguration($configuration)


### PR DESCRIPTION
These classes are children of `\Jenssegers\Model\Model` (or `\Swis\JsonApi\Client\Item` in the `swisnl/json-api-client:^2.0`) which declares a `fill`-method with a returning type `$this`. This MR adds return type to the childrens

Also, a `src/Item/CapacityPool.php` has a method `getRenewDate` with return type `\Date`. I suppose it should be `\DateTime`, not `\Date` (but it not yet fixed)

It should be great to add psalm/phpstan to dev dependency (these errors were found by psalm)