### PR TITLE
Add Laravel 13 support, drop EOL versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
       "php": ">=8.2",
       "swisnl/json-api-client": "^2.0",
-      "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+      "illuminate/support": "^12.0 || ^13.0",
       "guzzlehttp/guzzle": "^7.0",
       "phpseclib/phpseclib": "^3.0.7",
       "ext-openssl": "*",


### PR DESCRIPTION
Drop illuminate/support ^10.0 and ^11.0 (both EOL), add ^13.0

Closes #103