### PR TITLE
Remove illuminate/support dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require": {
       "php": ">=8.2",
       "swisnl/json-api-client": "^2.0",
-      "illuminate/support": "^12.0 || ^13.0",
       "guzzlehttp/guzzle": "^7.0",
       "phpseclib/phpseclib": "^3.0.7",
       "ext-openssl": "*",

--- a/src/Item/Address.php
+++ b/src/Item/Address.php
@@ -12,6 +12,11 @@ class Address extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/addresses';
+    }
+
     protected $type = 'addresses';
 
     public function getCityName(): string

--- a/src/Item/AddressVerification.php
+++ b/src/Item/AddressVerification.php
@@ -12,6 +12,11 @@ class AddressVerification extends BaseItem
     use Fetchable;
     use Saveable;
 
+    public static function getEndpoint(): string
+    {
+        return '/address_verifications';
+    }
+
     protected $type = 'address_verifications';
 
     public function getServiceDescription(): ?string

--- a/src/Item/Area.php
+++ b/src/Item/Area.php
@@ -8,6 +8,11 @@ class Area extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/areas';
+    }
+
     protected $type = 'areas';
 
     public function country()

--- a/src/Item/AvailableDid.php
+++ b/src/Item/AvailableDid.php
@@ -8,6 +8,11 @@ class AvailableDid extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/available_dids';
+    }
+
     protected $type = 'available_dids';
 
     public function didGroup()

--- a/src/Item/BaseItem.php
+++ b/src/Item/BaseItem.php
@@ -2,12 +2,13 @@
 
 namespace Didww\Item;
 
+use Didww\Traits\HasEnumAttributes;
 use Didww\Traits\HasSafeAttributes;
-use Illuminate\Support\Str;
 
 abstract class BaseItem extends \Swis\JsonApi\Client\Item
 {
     use HasSafeAttributes;
+    use HasEnumAttributes;
 
     protected array $persistedAttributes = [];
 
@@ -32,10 +33,7 @@ abstract class BaseItem extends \Swis\JsonApi\Client\Item
         return $repository;
     }
 
-    public static function getEndpoint(): string
-    {
-        return '/'.Str::snake(Str::plural(substr(get_called_class(), strrpos(get_called_class(), '\\') + 1)));
-    }
+    abstract public static function getEndpoint(): string;
 
     public function toJsonApiArray(): array
     {
@@ -84,40 +82,6 @@ abstract class BaseItem extends \Swis\JsonApi\Client\Item
         $current = $this->toJsonApiArray();
         $this->persistedAttributes = $current['attributes'] ?? [];
         $this->persistedRelationships = $this->extractRelationshipData($current['relationships'] ?? []);
-    }
-
-    protected function enumAttribute(string $key, string $enumClass): ?\BackedEnum
-    {
-        $val = $this->attribute($key);
-
-        return null !== $val ? $enumClass::from($val) : null;
-    }
-
-    protected function setEnumAttribute(string $key, mixed $value): void
-    {
-        $this->attributes[$key] = $value instanceof \BackedEnum ? $value->value : $value;
-    }
-
-    protected function setEnumArrayAttribute(string $key, array $values): void
-    {
-        $this->attributes[$key] = array_map(
-            fn ($v) => $v instanceof \BackedEnum ? $v->value : $v,
-            $values
-        );
-    }
-
-    protected function dateAttribute(string $key): ?\DateTime
-    {
-        $val = $this->attribute($key);
-
-        return null !== $val ? new \DateTime($val) : null;
-    }
-
-    protected function enumArrayAttribute(string $key, string $enumClass): ?array
-    {
-        $val = $this->attribute($key);
-
-        return null !== $val ? array_map(fn ($v) => $enumClass::from($v), $val) : null;
     }
 
     protected function getWhiteListAttributesKeys()

--- a/src/Item/CapacityPool.php
+++ b/src/Item/CapacityPool.php
@@ -10,6 +10,11 @@ class CapacityPool extends BaseItem
     use Saveable;
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/capacity_pools';
+    }
+
     protected $type = 'capacity_pools';
 
     public function countries()

--- a/src/Item/City.php
+++ b/src/Item/City.php
@@ -8,6 +8,11 @@ class City extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/cities';
+    }
+
     protected $type = 'cities';
 
     public function country()

--- a/src/Item/Configuration/Base.php
+++ b/src/Item/Configuration/Base.php
@@ -10,9 +10,14 @@ use Didww\Enum\SstRefreshMethod;
 use Didww\Enum\StirShakenMode;
 use Didww\Enum\TransportProtocol;
 use Didww\Enum\TxDtmfFormat;
+use Didww\Traits\HasEnumAttributes;
+use Didww\Traits\HasSafeAttributes;
 
-abstract class Base extends \Didww\Item\BaseItem
+abstract class Base
 {
+    use HasSafeAttributes;
+    use HasEnumAttributes;
+
     protected $attributes = [];
 
     public function __construct($attributes = [])

--- a/src/Item/Country.php
+++ b/src/Item/Country.php
@@ -8,6 +8,11 @@ class Country extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/countries';
+    }
+
     protected $type = 'countries';
 
     public function getName(): string

--- a/src/Item/Did.php
+++ b/src/Item/Did.php
@@ -10,6 +10,11 @@ class Did extends BaseItem
     use Saveable;
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/dids';
+    }
+
     protected $type = 'dids';
 
     public function setDedicatedChannelsCount(int $dedicatedChannelCount)

--- a/src/Item/DidGroup.php
+++ b/src/Item/DidGroup.php
@@ -9,6 +9,11 @@ class DidGroup extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/did_groups';
+    }
+
     protected $type = 'did_groups';
 
     public function stockKeepingUnits()

--- a/src/Item/DidGroupType.php
+++ b/src/Item/DidGroupType.php
@@ -8,5 +8,10 @@ class DidGroupType extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/did_group_types';
+    }
+
     protected $type = 'did_group_types';
 }

--- a/src/Item/DidReservation.php
+++ b/src/Item/DidReservation.php
@@ -12,6 +12,11 @@ class DidReservation extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/did_reservations';
+    }
+
     protected $type = 'did_reservations';
 
     public function availableDid()

--- a/src/Item/EncryptedFile.php
+++ b/src/Item/EncryptedFile.php
@@ -11,6 +11,11 @@ class EncryptedFile extends BaseItem
     use Fetchable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/encrypted_files';
+    }
+
     protected $type = 'encrypted_files';
 
     public function getDescription(): ?string

--- a/src/Item/Export.php
+++ b/src/Item/Export.php
@@ -12,6 +12,11 @@ class Export extends BaseItem
     use Saveable;
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/exports';
+    }
+
     protected $type = 'exports';
 
     private $filters = [];

--- a/src/Item/Identity.php
+++ b/src/Item/Identity.php
@@ -13,6 +13,11 @@ class Identity extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/identities';
+    }
+
     protected $type = 'identities';
 
     public function getFirstName(): string

--- a/src/Item/NanpaPrefix.php
+++ b/src/Item/NanpaPrefix.php
@@ -8,6 +8,11 @@ class NanpaPrefix extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/nanpa_prefixes';
+    }
+
     protected $type = 'nanpa_prefixes';
 
     public function country()

--- a/src/Item/Order.php
+++ b/src/Item/Order.php
@@ -17,6 +17,11 @@ class Order extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/orders';
+    }
+
     protected $type = 'orders';
 
     private const ITEM_CLASSES = [

--- a/src/Item/PermanentSupportingDocument.php
+++ b/src/Item/PermanentSupportingDocument.php
@@ -10,6 +10,11 @@ class PermanentSupportingDocument extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/permanent_supporting_documents';
+    }
+
     protected $type = 'permanent_supporting_documents';
 
     public function getCreatedAt(): ?\DateTime

--- a/src/Item/Pop.php
+++ b/src/Item/Pop.php
@@ -8,6 +8,11 @@ class Pop extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/pops';
+    }
+
     protected $type = 'pops';
 
     public function getName()

--- a/src/Item/Proof.php
+++ b/src/Item/Proof.php
@@ -10,6 +10,11 @@ class Proof extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/proofs';
+    }
+
     protected $type = 'proofs';
 
     public function getCreatedAt(): ?\DateTime

--- a/src/Item/ProofType.php
+++ b/src/Item/ProofType.php
@@ -8,6 +8,11 @@ class ProofType extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/proof_types';
+    }
+
     protected $type = 'proof_types';
 
     public function getName(): string

--- a/src/Item/PublicKey.php
+++ b/src/Item/PublicKey.php
@@ -8,6 +8,11 @@ class PublicKey extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/public_keys';
+    }
+
     protected $type = 'public_keys';
 
     public function getKey(): string

--- a/src/Item/QtyBasedPricing.php
+++ b/src/Item/QtyBasedPricing.php
@@ -4,5 +4,10 @@ namespace Didww\Item;
 
 class QtyBasedPricing extends BaseItem
 {
+    public static function getEndpoint(): string
+    {
+        return '/qty_based_pricings';
+    }
+
     protected $type = 'qty_based_pricings';
 }

--- a/src/Item/Region.php
+++ b/src/Item/Region.php
@@ -8,6 +8,11 @@ class Region extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/regions';
+    }
+
     protected $type = 'regions';
 
     public function country()

--- a/src/Item/Requirement.php
+++ b/src/Item/Requirement.php
@@ -10,6 +10,11 @@ class Requirement extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/requirements';
+    }
+
     protected $type = 'requirements';
 
     public function getIdentityType(): IdentityType

--- a/src/Item/RequirementValidation.php
+++ b/src/Item/RequirementValidation.php
@@ -8,6 +8,11 @@ class RequirementValidation extends BaseItem
 {
     use Saveable;
 
+    public static function getEndpoint(): string
+    {
+        return '/requirement_validations';
+    }
+
     protected $type = 'requirement_validations';
 
     public function requirement()

--- a/src/Item/SharedCapacityGroup.php
+++ b/src/Item/SharedCapacityGroup.php
@@ -12,6 +12,11 @@ class SharedCapacityGroup extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/shared_capacity_groups';
+    }
+
     protected $type = 'shared_capacity_groups';
 
     public function setName(string $name)

--- a/src/Item/StockKeepingUnit.php
+++ b/src/Item/StockKeepingUnit.php
@@ -4,6 +4,11 @@ namespace Didww\Item;
 
 class StockKeepingUnit extends BaseItem
 {
+    public static function getEndpoint(): string
+    {
+        return '/stock_keeping_units';
+    }
+
     protected $type = 'stock_keeping_units';
 
     public function getSetupPrice(): float

--- a/src/Item/SupportingDocumentTemplate.php
+++ b/src/Item/SupportingDocumentTemplate.php
@@ -8,6 +8,11 @@ class SupportingDocumentTemplate extends BaseItem
 {
     use Fetchable;
 
+    public static function getEndpoint(): string
+    {
+        return '/supporting_document_templates';
+    }
+
     protected $type = 'supporting_document_templates';
 
     public function getName(): string

--- a/src/Item/VoiceInTrunk.php
+++ b/src/Item/VoiceInTrunk.php
@@ -15,6 +15,11 @@ class VoiceInTrunk extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/voice_in_trunks';
+    }
+
     protected $type = 'voice_in_trunks';
 
     /**

--- a/src/Item/VoiceInTrunkGroup.php
+++ b/src/Item/VoiceInTrunkGroup.php
@@ -12,6 +12,11 @@ class VoiceInTrunkGroup extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/voice_in_trunk_groups';
+    }
+
     protected $type = 'voice_in_trunk_groups';
 
     public function voiceInTrunks()

--- a/src/Item/VoiceOutTrunk.php
+++ b/src/Item/VoiceOutTrunk.php
@@ -16,6 +16,11 @@ class VoiceOutTrunk extends BaseItem
     use Saveable;
     use Deletable;
 
+    public static function getEndpoint(): string
+    {
+        return '/voice_out_trunks';
+    }
+
     protected $type = 'voice_out_trunks';
 
     public function getName(): string

--- a/src/Item/VoiceOutTrunkRegenerateCredential.php
+++ b/src/Item/VoiceOutTrunkRegenerateCredential.php
@@ -8,6 +8,11 @@ class VoiceOutTrunkRegenerateCredential extends BaseItem
 {
     use Saveable;
 
+    public static function getEndpoint(): string
+    {
+        return '/voice_out_trunk_regenerate_credentials';
+    }
+
     protected $type = 'voice_out_trunk_regenerate_credentials';
 
     public function voiceOutTrunk()

--- a/src/Traits/HasEnumAttributes.php
+++ b/src/Traits/HasEnumAttributes.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Didww\Traits;
+
+trait HasEnumAttributes
+{
+    protected function enumAttribute(string $key, string $enumClass): ?\BackedEnum
+    {
+        $val = $this->attribute($key);
+
+        return null !== $val ? $enumClass::from($val) : null;
+    }
+
+    protected function setEnumAttribute(string $key, mixed $value): void
+    {
+        $this->attributes[$key] = $value instanceof \BackedEnum ? $value->value : $value;
+    }
+
+    protected function setEnumArrayAttribute(string $key, array $values): void
+    {
+        $this->attributes[$key] = array_map(
+            fn ($v) => $v instanceof \BackedEnum ? $v->value : $v,
+            $values
+        );
+    }
+
+    protected function enumArrayAttribute(string $key, string $enumClass): ?array
+    {
+        $val = $this->attribute($key);
+
+        return null !== $val ? array_map(fn ($v) => $enumClass::from($v), $val) : null;
+    }
+
+    protected function dateAttribute(string $key): ?\DateTime
+    {
+        $val = $this->attribute($key);
+
+        return null !== $val ? new \DateTime($val) : null;
+    }
+}


### PR DESCRIPTION
Extract enum/date helpers into HasEnumAttributes trait so Configuration\Base no longer needs to extend BaseItem. Each item class now defines its own getEndpoint() explicitly.