### PR TITLE
Replace deprecated curl_close() with unset()

### DIFF
--- a/src/Item/Export.php
+++ b/src/Item/Export.php
@@ -108,7 +108,7 @@ class Export extends BaseItem
         curl_setopt_array($ch, $options);
         $return = curl_exec($ch);
         $error = false === $return ? curl_error($ch) : null;
-        curl_close($ch);
+        unset($ch);
         if ($ownHandle) {
             fclose($destHandle);
         }


### PR DESCRIPTION
No-op since PHP 8.0 (CurlHandle objects), deprecated in PHP 8.5. https://php.watch/versions/8.5/curl_close-curl_share_close-deprecated