### PR TITLE
chore: upgrade PHPUnit and drop dms/phpunit-arraysubset-asserts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,10 @@
       "ext-json": "*"
     },
     "require-dev": {
-      "phpunit/phpunit": "^10.0|^11.0",
+      "phpunit/phpunit": "^10.5|^11.5",
       "php-vcr/php-vcr": "^1.4",
       "friendsofphp/php-cs-fixer": "^3.45",
-      "php-coveralls/php-coveralls": "^2.1",
-      "dms/phpunit-arraysubset-asserts": "^0.5"
+      "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {
       "psr-4": {
@@ -47,6 +46,9 @@
     "config": {
       "allow-plugins": {
         "php-http/discovery": true
+      },
+      "audit": {
+        "ignore": ["PKSA-5jz8-6tcw-pbk4", "PKSA-z3gr-8qht-p93v"]
       }
     }
 }

--- a/tests/AddressTest.php
+++ b/tests/AddressTest.php
@@ -2,12 +2,8 @@
 
 namespace Didww\Tests;
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-
 class AddressTest extends CassetteTest
 {
-    use ArraySubsetAsserts;
-
     protected function getCassetteName(): string
     {
         return 'addresses.yml';

--- a/tests/AddressVerificationTest.php
+++ b/tests/AddressVerificationTest.php
@@ -3,12 +3,9 @@
 namespace Didww\Tests;
 
 use Didww\Enum\AddressVerificationStatus;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 class AddressVerificationTest extends CassetteTest
 {
-    use ArraySubsetAsserts;
-
     protected function getCassetteName(): string
     {
         return 'address_verifications.yml';

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -30,4 +30,16 @@ abstract class BaseTest extends \PHPUnit\Framework\TestCase
     {
         return new \Didww\Credentials('PLACEYOURAPIKEYHERE', 'sandbox');
     }
+
+    protected static function assertArraySubset(array $subset, array $array, string $message = ''): void
+    {
+        foreach ($subset as $key => $value) {
+            static::assertArrayHasKey($key, $array, $message);
+            if (is_array($value) && is_array($array[$key])) {
+                static::assertArraySubset($value, $array[$key], $message);
+            } else {
+                static::assertEquals($value, $array[$key], $message);
+            }
+        }
+    }
 }

--- a/tests/IdentityTest.php
+++ b/tests/IdentityTest.php
@@ -2,12 +2,8 @@
 
 namespace Didww\Tests;
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-
 class IdentityTest extends CassetteTest
 {
-    use ArraySubsetAsserts;
-
     protected function getCassetteName(): string
     {
         return 'identities.yml';

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -133,9 +133,7 @@ class RequestValidatorTest extends BaseTest
         ];
     }
 
-    /**
-     * @dataProvider urlNormalizationProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('urlNormalizationProvider')]
     public function testUrlNormalization(string $url, string $expectedSignature)
     {
         $apiKey = 'SOMEAPIKEY';

--- a/tests/VoiceInTrunkGroupTest.php
+++ b/tests/VoiceInTrunkGroupTest.php
@@ -2,12 +2,8 @@
 
 namespace Didww\Tests;
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-
 class VoiceInTrunkGroupTest extends CassetteTest
 {
-    use ArraySubsetAsserts;
-
     protected function getCassetteName(): string
     {
         return 'voice_in_trunk_groups.yml';

--- a/tests/VoiceInTrunkTest.php
+++ b/tests/VoiceInTrunkTest.php
@@ -9,12 +9,9 @@ use Didww\Enum\SstRefreshMethod;
 use Didww\Enum\StirShakenMode;
 use Didww\Enum\TransportProtocol;
 use Didww\Enum\TxDtmfFormat;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 class VoiceInTrunkTest extends CassetteTest
 {
-    use ArraySubsetAsserts;
-
     protected function getCassetteName(): string
     {
         return 'voice_in_trunks.yml';


### PR DESCRIPTION
## Summary
- Remove `dms/phpunit-arraysubset-asserts` dependency (incompatible with PHPUnit 11+)
- Add `assertArraySubset` helper to `BaseTest` for backward compatibility
- Ignore PHPUnit security advisories (PKSA-5jz8-6tcw-pbk4, PKSA-z3gr-8qht-p93v) that block Composer install — these affect PHPUnit internals, not the SDK
- Keep PHPUnit range as `^10.5|^11.5` (supports PHP 8.2+)

## Test plan
- [x] 189 tests pass locally on PHP 8.5
- [x] PHP CS Fixer clean
- [x] CI passes on PHP 8.2, 8.3, 8.4