### PR TITLE
Fix post-rollout: requirement_validations 201 (not 204) + isCanceled rename

### DIFF
--- a/examples/emergency_requirement_validations.php
+++ b/examples/emergency_requirement_validations.php
@@ -27,5 +27,5 @@ if ($document->hasErrors()) {
     echo "Validation failed:\n";
     var_dump($document->getErrors());
 } else {
-    echo "Validation successful (HTTP 204)\n";
+    echo "Validation successful (HTTP 201)\n";
 }

--- a/src/Item/EmergencyRequirementValidation.php
+++ b/src/Item/EmergencyRequirementValidation.php
@@ -8,7 +8,8 @@ use Didww\Traits\Saveable;
  * Validates a prospective emergency calling service order against
  * an EmergencyRequirement, given an Address and an Identity.
  *
- * Write-only endpoint: a successful POST returns 204 No Content.
+ * A successful POST returns 201 Created with the validation resource
+ * (id mirrors the submitted emergency_requirement_id).
  * Introduced in API 2026-04-16.
  */
 class EmergencyRequirementValidation extends BaseItem

--- a/src/Item/Order.php
+++ b/src/Item/Order.php
@@ -119,7 +119,7 @@ class Order extends BaseItem
         return OrderStatus::COMPLETED === $this->getStatus();
     }
 
-    public function isCancelled(): bool
+    public function isCanceled(): bool
     {
         return OrderStatus::CANCELED === $this->getStatus();
     }

--- a/tests/AddressRequirementValidationTest.php
+++ b/tests/AddressRequirementValidationTest.php
@@ -21,6 +21,7 @@ class AddressRequirementValidationTest extends CassetteTest
         $this->assertFalse($requirementValidationDocument->hasErrors());
         $requirementValidation = $requirementValidationDocument->getData();
         $this->assertInstanceOf('Didww\Item\AddressRequirementValidation', $requirementValidation);
+        $this->assertEquals('aea92b24-a044-4864-9740-89d3e15b65c7', $requirementValidation->getId());
     }
 
     public function testCreateAddressRequirementValidationFailed()
@@ -35,18 +36,6 @@ class AddressRequirementValidationTest extends CassetteTest
         $requirementValidation->setAddressRequirement($requirement);
         $requirementValidationDocument = $requirementValidation->save();
         $this->assertTrue($requirementValidationDocument->hasErrors());
-    }
-
-    public function testCreateAddressRequirementValidation204()
-    {
-        $address = \Didww\Item\Address::build('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
-        $requirement = \Didww\Item\AddressRequirement::build('11111111-2222-3333-4444-555555555555');
-
-        $validation = new \Didww\Item\AddressRequirementValidation();
-        $validation->setAddress($address);
-        $validation->setAddressRequirement($requirement);
-        $document = $validation->save();
-        $this->assertFalse($document->hasErrors());
     }
 
     public function testEndpoint()

--- a/tests/EmergencyRequirementValidationTest.php
+++ b/tests/EmergencyRequirementValidationTest.php
@@ -23,20 +23,7 @@ class EmergencyRequirementValidationTest extends CassetteTest
         $this->assertFalse($document->hasErrors());
         $data = $document->getData();
         $this->assertInstanceOf('Didww\Item\EmergencyRequirementValidation', $data);
-    }
-
-    public function testCreateEmergencyRequirementValidation204()
-    {
-        $address = \Didww\Item\Address::build('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
-        $identity = \Didww\Item\Identity::build('11111111-aaaa-bbbb-cccc-dddddddddddd');
-        $emergencyRequirement = \Didww\Item\EmergencyRequirement::build('22222222-3333-4444-5555-666666666666');
-
-        $validation = new \Didww\Item\EmergencyRequirementValidation();
-        $validation->setAddress($address);
-        $validation->setIdentity($identity);
-        $validation->setEmergencyRequirement($emergencyRequirement);
-        $document = $validation->save();
-        $this->assertFalse($document->hasErrors());
+        $this->assertEquals('aea92b24-a044-4864-9740-89d3e15b65c7', $data->getId());
     }
 
     public function testEndpoint()

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -403,16 +403,16 @@ class OrderTest extends BaseTest
         $pending = new \Didww\Item\Order(['status' => 'pending']);
         $this->assertTrue($pending->isPending());
         $this->assertFalse($pending->isCompleted());
-        $this->assertFalse($pending->isCancelled());
+        $this->assertFalse($pending->isCanceled());
 
         $completed = new \Didww\Item\Order(['status' => 'completed']);
         $this->assertFalse($completed->isPending());
         $this->assertTrue($completed->isCompleted());
-        $this->assertFalse($completed->isCancelled());
+        $this->assertFalse($completed->isCanceled());
 
-        $cancelled = new \Didww\Item\Order(['status' => 'canceled']);
-        $this->assertFalse($cancelled->isPending());
-        $this->assertFalse($cancelled->isCompleted());
-        $this->assertTrue($cancelled->isCancelled());
+        $canceled = new \Didww\Item\Order(['status' => 'canceled']);
+        $this->assertFalse($canceled->isPending());
+        $this->assertFalse($canceled->isCompleted());
+        $this->assertTrue($canceled->isCanceled());
     }
 }

--- a/tests/fixtures/address_requirement_validations.yml
+++ b/tests/fixtures/address_requirement_validations.yml
@@ -47,25 +47,3 @@
             Transfer-Encoding: chunked
             Connection: keep-alive
         body: '{"errors":[{"title":"Identity Place of Birth must be Belgium","detail":"Identity Place of Birth must be Belgium","code":"100","source":{"pointer":"/data"},"status":"422"},{"title":"Following Supporting Document(s) required (Belgium Registration Form)","detail":"Following Supporting Document(s) required (Belgium Registration Form)","code":"100","source":{"pointer":"/data"},"status":"422"},{"title":"Address in Belgium required","detail":"Address in Belgium required","code":"100","source":{"pointer":"/data"},"status":"422"}]}'
--
-    request:
-        method: POST
-        url: 'https://sandbox-api.didww.com/v3/address_requirement_validations'
-        headers:
-            Host: sandbox-api.didww.com
-            Accept-Encoding: ''
-            User-Agent: GuzzleHttp/7
-            Accept: application/vnd.api+json
-            Content-Type: application/vnd.api+json
-            api-key: PLACEYOURAPIKEYHERE
-        body: '{"data":{"type":"address_requirement_validations","relationships":{"address":{"data":{"type":"addresses","id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}},"address_requirement":{"data":{"type":"address_requirements","id":"11111111-2222-3333-4444-555555555555"}}}}}'
-    response:
-        status:
-            http_version: '1.1'
-            code: '204'
-            message: 'No Content'
-        headers:
-            Server: nginx
-            Date: 'Thu, 01 Apr 2021 15:02:00 GMT'
-            Connection: keep-alive
-        body: ''

--- a/tests/fixtures/emergency_requirement_validations.yml
+++ b/tests/fixtures/emergency_requirement_validations.yml
@@ -19,27 +19,4 @@
             message: Created
         headers:
             Content-Type: application/vnd.api+json
-        body: '{"data":{"id":"aea92b24-a044-4864-9740-89d3e15b65c7","type":"emergency_requirement_validations"}}'
--
-    request:
-        method: POST
-        url: 'https://sandbox-api.didww.com/v3/emergency_requirement_validations'
-        headers:
-            Host: sandbox-api.didww.com
-            Expect: ''
-            Accept-Encoding: ''
-            User-Agent: GuzzleHttp/7
-            Accept: application/vnd.api+json
-            Content-Type: application/vnd.api+json
-            api-key: PLACEYOURAPIKEYHERE
-        body: '{"data":{"type":"emergency_requirement_validations","relationships":{"address":{"data":{"type":"addresses","id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}},"identity":{"data":{"type":"identities","id":"11111111-aaaa-bbbb-cccc-dddddddddddd"}},"emergency_requirement":{"data":{"type":"emergency_requirements","id":"22222222-3333-4444-5555-666666666666"}}}}}'
-    response:
-        status:
-            http_version: '1.1'
-            code: '204'
-            message: 'No Content'
-        headers:
-            Server: nginx
-            Date: 'Thu, 01 Apr 2021 15:02:00 GMT'
-            Connection: keep-alive
-        body: ''
+        body: '{"data":{"id":"aea92b24-a044-4864-9740-89d3e15b65c7","type":"emergency_requirement_validations"},"meta":{"api_version":"2026-04-16"}}'


### PR DESCRIPTION
## Summary

Post-rollout cleanup for the 2026-04-16 API branch, based on sandbox verification findings.

### Commit 1 — `fix: requirement_validations POST returns 201 with body, not 204`

Sandbox verification of `POST /v3/emergency_requirement_validations` and `POST /v3/address_requirement_validations` confirmed both endpoints return:

- HTTP **201 Created**
- JSON:API body: `{"data":{"id":"<uuid>","type":"..."},"meta":{"api_version":"2026-04-16"}}`
- `data.id` mirrors the submitted `requirement_id` / `emergency_requirement_id`

The SDK had test/example/docstring text claiming HTTP 204 No Content. Cleaned up:

- Deleted `testCreateEmergencyRequirementValidation204` (synthetic 204 test).
- Deleted `testCreateAddressRequirementValidation204` (synthetic 204 test).
- Removed the orphaned 204 fixture entries from `tests/fixtures/{emergency_,address_}requirement_validations.yml`.
- Enhanced existing happy-path 201 tests to also assert `$data->getId()` matches the submitted requirement id.
- Updated `EmergencyRequirementValidation` class docblock to describe 201 behavior.
- Updated `examples/emergency_requirement_validations.php` success message from `HTTP 204` → `HTTP 201`.
- Added `meta.api_version` to the emergency fixture 201 response body for parity with the address fixture / real server.

### Commit 2 — `refactor!: rename isCancelled to isCanceled for wire-format consistency`

Server wire value is `"canceled"` (single L). The helper `Order::isCancelled()` used double L, inconsistent with the wire format. Renamed to `Order::isCanceled()`.

**Safe break:** `isCancelled` was added on `feat/api-2026-04-16` and is not part of released v9.0.0, so no external consumers depend on the old name.

## Test plan

- [x] `vendor/bin/phpunit` — 239 tests / 1201 assertions passing locally on PHP 8.5.4 after commit 1.
- [x] `vendor/bin/phpunit tests/OrderTest.php` — 15 tests passing after commit 2.
- [x] `vendor/bin/phpunit` — full suite still 239 / 1201 green after commit 2.
- [x] `grep isCancelled` — no remaining references.
- [x] CI green on the PR.