### PR TITLE
code cleanup

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -8,6 +8,8 @@ class Configuration
 
     private static $credentials;
 
+    private static $httpClient;
+
     public static function getCredentials()
     {
         return self::$credentials;
@@ -18,11 +20,17 @@ class Configuration
         return self::$documentClient;
     }
 
+    public static function getHttpClient()
+    {
+        return self::$httpClient;
+    }
+
     public static function configure(Credentials $credentials, array $httpClientConfig = [])
     {
         self::$credentials = $credentials;
 
         $httpClient = new \GuzzleHttp\Client($httpClientConfig);
+        self::$httpClient = $httpClient;
 
         $client = new Client($httpClient);
         $client->setBaseUri($credentials->getEndpoint());

--- a/src/Item/Export.php
+++ b/src/Item/Export.php
@@ -156,7 +156,7 @@ class Export extends BaseItem
             return $result;
         }
 
-        $gz = gzopen($tmpFile, 'rb');
+        $gz = fopen('compress.zlib://'.$tmpFile, 'rb');
         if (false === $gz) {
             unlink($tmpFile);
 
@@ -166,15 +166,13 @@ class Export extends BaseItem
         $ownHandle = !is_resource($dest);
         $destHandle = $ownHandle ? fopen($dest, 'wb') : $dest;
         if ($ownHandle && false === $destHandle) {
-            gzclose($gz);
+            fclose($gz);
             unlink($tmpFile);
 
             return 'Failed to open destination file for writing';
         }
-        while (!gzeof($gz)) {
-            fwrite($destHandle, gzread($gz, 8192));
-        }
-        gzclose($gz);
+        stream_copy_to_stream($gz, $destHandle);
+        fclose($gz);
         if ($ownHandle) {
             fclose($destHandle);
         }

--- a/src/Item/Export.php
+++ b/src/Item/Export.php
@@ -119,23 +119,24 @@ class Export extends BaseItem
             return 'Failed to open destination file for writing';
         }
 
-        $options = [
-            CURLOPT_HTTPHEADER => [
-                "Api-Key: $apiKey",
-                'User-Agent: didww-php-sdk/'.\Didww\Client::sdkVersion(),
-                'X-DIDWW-API-Version: '.(\Didww\Configuration::getCredentials()->getVersion() ?? '2026-04-16'),
-            ],
-            CURLOPT_FILE => $destHandle,
-            CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_URL => $this->getAttributes()['url'],
-            CURLOPT_FAILONERROR => true, // HTTP code > 400 will throw curl error
-        ];
-        $ch = curl_init();
-        curl_setopt_array($ch, $options);
-        $return = curl_exec($ch);
-        $error = false === $return ? curl_error($ch) : null;
-        unset($ch);
-        if ($ownHandle) {
+        try {
+            \Didww\Configuration::getHttpClient()->request('GET', $this->getAttributes()['url'], [
+                'headers' => [
+                    'Api-Key' => $apiKey,
+                    'User-Agent' => 'didww-php-sdk/'.\Didww\Client::sdkVersion(),
+                    'X-DIDWW-API-Version' => \Didww\Configuration::getCredentials()->getVersion() ?? '2026-04-16',
+                ],
+                'sink' => $destHandle,
+                'allow_redirects' => true,
+                // HTTP code >= 400 will throw a GuzzleException, same as CURLOPT_FAILONERROR before.
+            ]);
+            $error = null;
+        } catch (\GuzzleHttp\Exception\GuzzleException $e) {
+            $error = $e->getMessage();
+        }
+        // Guzzle's 'sink' stream wrapper already closes the underlying resource once
+        // the response body has been written to it.
+        if ($ownHandle && is_resource($destHandle)) {
             fclose($destHandle);
         }
 


### PR DESCRIPTION
Fixes a real gap: Export::download()/downloadAndDecompress() built their own curl handle from scratch, bypassing whatever the consumer passed to Configuration::configure($credentials, $httpClientConfig) — proxy, timeout, SSL options, custom middleware all silently didn't apply to downloads (and downloads had no timeout at all, so they could hang indefinitely). Routes both methods through the SDK's shared, already-configured Guzzle client instead, via a new Configuration::getHttpClient() seam, so consumer HTTP config now actually applies everywhere. Not a line-count reduction (net +7 lines — the seam is new code). No behavior changes for the happy path, all tests pass.